### PR TITLE
adds Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.zip
+data
+deaths.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,55 @@
+BASE = http://cancelthesefunerals.com
+
+# note that .txt suffix is included is applicable
+TEXTS = monthly/ma130101.txt \
+	monthly/ma130201.txt \
+	monthly/ma130301.txt \
+	monthly/ma130401.txt \
+	monthly/ma130501.txt \
+	monthly/ma130601.txt \
+	monthly/ma130701.txt \
+	monthly/ma130801.txt \
+	monthly/ma130901.txt \
+	monthly/ma131001.txt \
+	monthly/ma131101.txt \
+	monthly/ma131201.txt \
+	monthly/ma140101.txt \
+	monthly/ma140201.txt \
+	monthly/ma140301.txt \
+	20111130/ssdm2 \
+	20111130/ssdm3
+
+# note that .zip suffix is omitted
+ZIPS = 20130531/ssdm1 \
+	20130531/ssdm2 \
+	20130531/ssdm3
+
+FOLDERS = monthly \
+	20111130 \
+	20130531
+
+LOAD_TASKS = $(addprefix LOAD_,$(TEXTS) $(ZIPS))
+
+.PHONY: index $(LOAD_TASKS)
+
+index: deaths.db 2_index_deaths.sql | $(LOAD_TASKS)
+	sqlite3 $< < 2_index_deaths.sql
+
+$(LOAD_TASKS): LOAD_%: deaths.db data/%.sql
+	sqlite3 $< < $(word 2,$^)
+
+deaths.db: 1_setup_deaths_db.sql
+	sqlite3 $@ < $<
+
+.SECONDARYEXPANSION:
+data/%.sql: data/% | $($*D)
+	perl ./txt2sql.pl < $< > $@
+
+$(addprefix data/,$(TEXTS)): data/%: | $($*D)
+	curl $(BASE)/$* > $@
+
+$(addprefix data/,$(ZIPS)): data/%: | $($*D)
+	curl $(BASE)/20111130/$*.zip | unzip -p > $@
+
+$(addprefix data/,$(FOLDERS)) $(addprefix sql/,$(FOLDERS)):
+	mkdir -p $@

--- a/README.md
+++ b/README.md
@@ -5,18 +5,15 @@
 
 # Converting the deaths to sqlite3
 
-1. Expect the current directory to grow to ~22GB.
-1. Put all the zipped death files into the `data` dir.
-   1. `sqlite3 deaths.db < 1_setup_deaths_db.sql`
+Expect the current directory to grow to ~22GB.
+
+````bash
+$ make
+````
+
+This will:
+1. Download the (very large) data files from http://cancelthesefunerals.com/ into the data dir
+1. Create a `deaths.db` sqlite database
 1. Convert the data (takes a while)
-   1. `./zips2sql.sh > deaths.sql`
-   1. OR, if you like PV; `./zips2sql.sh |pv -s 9g > deaths.sql`
-1. Actually import the deaths
-   1. `sqlite3 deaths.db < deaths.sql`
-1. Run all the indexes/virtual table stuff
-   1. `sqlite3 < 2_index_deaths.sql`
-
-
-   
-   
-   
+1. Import the deaths into `deaths.db`
+1. Run indexes and virtual table stuff

--- a/zips2sql.sh
+++ b/zips2sql.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-for x in `ls data/ss* && ls data/ma*`;
-do unzip -p $x;
-done | ./txt2sql.pl
-


### PR DESCRIPTION
Because make is fun like 🍰.
-  replaces zip2sql.sh.
- txt2sql.pl no longer runs on all downloads at once - one sql import
  is generated for each download file.
- dummy LOAD_% tasks add data to deaths.db, so don’t run make more than
  once! I guess that could be set up differently.
